### PR TITLE
Run custom node installer during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,9 @@ RUN pip uninstall -y numpy && pip install --no-cache-dir numpy==1.26.4
 # Clean up pip cache
 RUN rm -rf /root/.cache/pip
 
-# Copy the new custom node installer script
+# Copy the custom node installer script and run it so dependencies are baked in
 COPY --chmod=755 install_custom_nodes.sh /opt/install_custom_nodes.sh
+RUN /opt/install_custom_nodes.sh
 # Copy scripts and workflows
 COPY --chmod=755 start.sh /opt/start.sh
 COPY --chmod=755 scripts/ /workspace/scripts/


### PR DESCRIPTION
## Summary
- run install_custom_nodes.sh in Docker build to bake in dependencies

## Testing
- `git status --short`
- ❌ `docker --version`

------
https://chatgpt.com/codex/tasks/task_e_687ac1085be083318079be6646b8fa27